### PR TITLE
Convert C++ code to Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "opencolorio"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+log = "0.4"
+thiserror = "1.0"

--- a/src/OpenColorIO/CPUProcessor.rs
+++ b/src/OpenColorIO/CPUProcessor.rs
@@ -1,0 +1,257 @@
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Debug)]
+pub struct CPUProcessor {
+    impl_: Arc<Mutex<Impl>>,
+}
+
+#[derive(Clone, Debug)]
+struct Impl {
+    in_bit_depth_op: Option<Box<dyn OpCPU>>,
+    cpu_ops: Vec<Box<dyn OpCPU>>,
+    out_bit_depth_op: Option<Box<dyn OpCPU>>,
+    in_bit_depth: BitDepth,
+    out_bit_depth: BitDepth,
+    is_no_op: bool,
+    is_identity: bool,
+    has_channel_crosstalk: bool,
+    cache_id: String,
+}
+
+impl Impl {
+    fn new() -> Self {
+        Impl {
+            in_bit_depth_op: None,
+            cpu_ops: Vec::new(),
+            out_bit_depth_op: None,
+            in_bit_depth: BitDepth::F32,
+            out_bit_depth: BitDepth::F32,
+            is_no_op: false,
+            is_identity: false,
+            has_channel_crosstalk: true,
+            cache_id: String::new(),
+        }
+    }
+
+    fn is_dynamic(&self) -> bool {
+        if let Some(ref op) = self.in_bit_depth_op {
+            if op.is_dynamic() {
+                return true;
+            }
+        }
+
+        for op in &self.cpu_ops {
+            if op.is_dynamic() {
+                return true;
+            }
+        }
+
+        if let Some(ref op) = self.out_bit_depth_op {
+            if op.is_dynamic() {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn has_dynamic_property(&self, property_type: DynamicPropertyType) -> bool {
+        if let Some(ref op) = self.in_bit_depth_op {
+            if op.has_dynamic_property(property_type) {
+                return true;
+            }
+        }
+
+        for op in &self.cpu_ops {
+            if op.has_dynamic_property(property_type) {
+                return true;
+            }
+        }
+
+        if let Some(ref op) = self.out_bit_depth_op {
+            if op.has_dynamic_property(property_type) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn get_dynamic_property(&self, property_type: DynamicPropertyType) -> DynamicPropertyRcPtr {
+        if let Some(ref op) = self.in_bit_depth_op {
+            if op.has_dynamic_property(property_type) {
+                return op.get_dynamic_property(property_type);
+            }
+        }
+
+        for op in &self.cpu_ops {
+            if op.has_dynamic_property(property_type) {
+                return op.get_dynamic_property(property_type);
+            }
+        }
+
+        if let Some(ref op) = self.out_bit_depth_op {
+            if op.has_dynamic_property(property_type) {
+                return op.get_dynamic_property(property_type);
+            }
+        }
+
+        panic!("Cannot find dynamic property; not used by CPU processor.");
+    }
+
+    fn finalize(&mut self, raw_ops: &OpRcPtrVec, in_bit_depth: BitDepth, out_bit_depth: BitDepth, optimization_flags: OptimizationFlags) {
+        let mut ops = raw_ops.clone();
+        ops.finalize();
+        ops.optimize(optimization_flags);
+        ops.optimize_for_bitdepth(in_bit_depth, out_bit_depth, optimization_flags);
+
+        self.in_bit_depth = in_bit_depth;
+        self.out_bit_depth = out_bit_depth;
+
+        self.is_identity = ops.is_no_op();
+        self.is_no_op = self.is_identity && self.in_bit_depth == self.out_bit_depth;
+
+        self.has_channel_crosstalk = ops.has_channel_crosstalk();
+
+        self.cpu_ops.clear();
+        self.in_bit_depth_op = None;
+        self.out_bit_depth_op = None;
+        create_cpu_engine(&ops, in_bit_depth, out_bit_depth, optimization_flags, &mut self.in_bit_depth_op, &mut self.cpu_ops, &mut self.out_bit_depth_op);
+
+        let mut ss = String::new();
+        ss.push_str(&format!("CPU Processor: from {:?} to {:?} oFlags {:?} ops: {}", in_bit_depth, out_bit_depth, optimization_flags, ops.get_cache_id()));
+        self.cache_id = ss;
+    }
+
+    fn apply(&self, img_desc: &ImageDesc) {
+        let mut scanline_builder = create_scanline_helper(self.in_bit_depth, &self.in_bit_depth_op, self.out_bit_depth, &self.out_bit_depth_op);
+        scanline_builder.init(img_desc);
+
+        let mut rgba_buffer: Option<&mut [f32]> = None;
+        let mut num_pixels = 0;
+
+        while {
+            scanline_builder.prep_rgba_scanline(&mut rgba_buffer, &mut num_pixels);
+            num_pixels > 0
+        } {
+            for op in &self.cpu_ops {
+                op.apply(rgba_buffer.as_mut().unwrap(), rgba_buffer.as_mut().unwrap(), num_pixels);
+            }
+
+            scanline_builder.finish_rgba_scanline();
+        }
+    }
+
+    fn apply_with_dst(&self, src_img_desc: &ImageDesc, dst_img_desc: &mut ImageDesc) {
+        let mut scanline_builder = create_scanline_helper(self.in_bit_depth, &self.in_bit_depth_op, self.out_bit_depth, &self.out_bit_depth_op);
+        scanline_builder.init_with_dst(src_img_desc, dst_img_desc);
+
+        let mut rgba_buffer: Option<&mut [f32]> = None;
+        let mut num_pixels = 0;
+
+        while {
+            scanline_builder.prep_rgba_scanline(&mut rgba_buffer, &mut num_pixels);
+            num_pixels > 0
+        } {
+            for op in &self.cpu_ops {
+                op.apply(rgba_buffer.as_mut().unwrap(), rgba_buffer.as_mut().unwrap(), num_pixels);
+            }
+
+            scanline_builder.finish_rgba_scanline();
+        }
+    }
+
+    fn apply_rgb(&self, pixel: &mut [f32; 3]) {
+        let mut v = [pixel[0], pixel[1], pixel[2], 0.0];
+
+        if let Some(ref op) = self.in_bit_depth_op {
+            op.apply(&mut v, &mut v, 1);
+        }
+
+        for op in &self.cpu_ops {
+            op.apply(&mut v, &mut v, 1);
+        }
+
+        if let Some(ref op) = self.out_bit_depth_op {
+            op.apply(&mut v, &mut v, 1);
+        }
+
+        pixel[0] = v[0];
+        pixel[1] = v[1];
+        pixel[2] = v[2];
+    }
+
+    fn apply_rgba(&self, pixel: &mut [f32; 4]) {
+        if let Some(ref op) = self.in_bit_depth_op {
+            op.apply(pixel, pixel, 1);
+        }
+
+        for op in &self.cpu_ops {
+            op.apply(pixel, pixel, 1);
+        }
+
+        if let Some(ref op) = self.out_bit_depth_op {
+            op.apply(pixel, pixel, 1);
+        }
+    }
+}
+
+impl CPUProcessor {
+    pub fn new() -> Self {
+        CPUProcessor {
+            impl_: Arc::new(Mutex::new(Impl::new())),
+        }
+    }
+
+    pub fn is_no_op(&self) -> bool {
+        self.impl_.lock().unwrap().is_no_op
+    }
+
+    pub fn is_identity(&self) -> bool {
+        self.impl_.lock().unwrap().is_identity
+    }
+
+    pub fn has_channel_crosstalk(&self) -> bool {
+        self.impl_.lock().unwrap().has_channel_crosstalk
+    }
+
+    pub fn get_cache_id(&self) -> String {
+        self.impl_.lock().unwrap().cache_id.clone()
+    }
+
+    pub fn get_input_bit_depth(&self) -> BitDepth {
+        self.impl_.lock().unwrap().in_bit_depth
+    }
+
+    pub fn get_output_bit_depth(&self) -> BitDepth {
+        self.impl_.lock().unwrap().out_bit_depth
+    }
+
+    pub fn is_dynamic(&self) -> bool {
+        self.impl_.lock().unwrap().is_dynamic()
+    }
+
+    pub fn has_dynamic_property(&self, property_type: DynamicPropertyType) -> bool {
+        self.impl_.lock().unwrap().has_dynamic_property(property_type)
+    }
+
+    pub fn get_dynamic_property(&self, property_type: DynamicPropertyType) -> DynamicPropertyRcPtr {
+        self.impl_.lock().unwrap().get_dynamic_property(property_type)
+    }
+
+    pub fn apply(&self, img_desc: &ImageDesc) {
+        self.impl_.lock().unwrap().apply(img_desc)
+    }
+
+    pub fn apply_with_dst(&self, src_img_desc: &ImageDesc, dst_img_desc: &mut ImageDesc) {
+        self.impl_.lock().unwrap().apply_with_dst(src_img_desc, dst_img_desc)
+    }
+
+    pub fn apply_rgb(&self, pixel: &mut [f32; 3]) {
+        self.impl_.lock().unwrap().apply_rgb(pixel)
+    }
+
+    pub fn apply_rgba(&self, pixel: &mut [f32; 4]) {
+        self.impl_.lock().unwrap().apply_rgba(pixel)
+    }
+}

--- a/src/OpenColorIO/ColorSpace.rs
+++ b/src/OpenColorIO/ColorSpace.rs
@@ -1,0 +1,288 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+
+#[derive(Clone, Debug)]
+pub struct ColorSpace {
+    impl_: Arc<Mutex<Impl>>,
+}
+
+#[derive(Clone, Debug)]
+struct Impl {
+    name: String,
+    family: String,
+    equality_group: String,
+    description: String,
+    encoding: String,
+    aliases: Vec<String>,
+    bit_depth: BitDepth,
+    is_data: bool,
+    reference_space_type: ReferenceSpaceType,
+    allocation: Allocation,
+    allocation_vars: Vec<f32>,
+    to_ref_transform: Option<TransformRcPtr>,
+    from_ref_transform: Option<TransformRcPtr>,
+    to_ref_specified: bool,
+    from_ref_specified: bool,
+    categories: TokensManager,
+}
+
+impl Impl {
+    fn new(reference_space: ReferenceSpaceType) -> Self {
+        Impl {
+            name: String::new(),
+            family: String::new(),
+            equality_group: String::new(),
+            description: String::new(),
+            encoding: String::new(),
+            aliases: Vec::new(),
+            bit_depth: BitDepth::Unknown,
+            is_data: false,
+            reference_space_type: reference_space,
+            allocation: Allocation::Uniform,
+            allocation_vars: Vec::new(),
+            to_ref_transform: None,
+            from_ref_transform: None,
+            to_ref_specified: false,
+            from_ref_specified: false,
+            categories: TokensManager::new(),
+        }
+    }
+}
+
+impl ColorSpace {
+    pub fn create() -> ColorSpaceRcPtr {
+        Arc::new(ColorSpace {
+            impl_: Arc::new(Mutex::new(Impl::new(ReferenceSpaceType::Scene))),
+        })
+    }
+
+    pub fn create_with_reference_space(reference_space: ReferenceSpaceType) -> ColorSpaceRcPtr {
+        Arc::new(ColorSpace {
+            impl_: Arc::new(Mutex::new(Impl::new(reference_space))),
+        })
+    }
+
+    pub fn create_editable_copy(&self) -> ColorSpaceRcPtr {
+        let impl_copy = self.impl_.lock().unwrap().clone();
+        Arc::new(ColorSpace {
+            impl_: Arc::new(Mutex::new(impl_copy)),
+        })
+    }
+
+    pub fn get_name(&self) -> String {
+        self.impl_.lock().unwrap().name.clone()
+    }
+
+    pub fn set_name(&self, name: &str) {
+        let mut impl_ = self.impl_.lock().unwrap();
+        impl_.name = name.to_string();
+        impl_.aliases.retain(|alias| alias != name);
+    }
+
+    pub fn get_num_aliases(&self) -> usize {
+        self.impl_.lock().unwrap().aliases.len()
+    }
+
+    pub fn get_alias(&self, idx: usize) -> String {
+        self.impl_.lock().unwrap().aliases.get(idx).cloned().unwrap_or_default()
+    }
+
+    pub fn has_alias(&self, alias: &str) -> bool {
+        self.impl_.lock().unwrap().aliases.iter().any(|a| a.eq_ignore_ascii_case(alias))
+    }
+
+    pub fn add_alias(&self, alias: &str) {
+        let mut impl_ = self.impl_.lock().unwrap();
+        if alias != impl_.name && !impl_.aliases.contains(&alias.to_string()) {
+            impl_.aliases.push(alias.to_string());
+        }
+    }
+
+    pub fn remove_alias(&self, alias: &str) {
+        let mut impl_ = self.impl_.lock().unwrap();
+        impl_.aliases.retain(|a| a != alias);
+    }
+
+    pub fn clear_aliases(&self) {
+        self.impl_.lock().unwrap().aliases.clear();
+    }
+
+    pub fn get_family(&self) -> String {
+        self.impl_.lock().unwrap().family.clone()
+    }
+
+    pub fn set_family(&self, family: &str) {
+        self.impl_.lock().unwrap().family = family.to_string();
+    }
+
+    pub fn get_equality_group(&self) -> String {
+        self.impl_.lock().unwrap().equality_group.clone()
+    }
+
+    pub fn set_equality_group(&self, equality_group: &str) {
+        self.impl_.lock().unwrap().equality_group = equality_group.to_string();
+    }
+
+    pub fn get_description(&self) -> String {
+        self.impl_.lock().unwrap().description.clone()
+    }
+
+    pub fn set_description(&self, description: &str) {
+        self.impl_.lock().unwrap().description = description.to_string();
+    }
+
+    pub fn get_bit_depth(&self) -> BitDepth {
+        self.impl_.lock().unwrap().bit_depth
+    }
+
+    pub fn set_bit_depth(&self, bit_depth: BitDepth) {
+        self.impl_.lock().unwrap().bit_depth = bit_depth;
+    }
+
+    pub fn has_category(&self, category: &str) -> bool {
+        self.impl_.lock().unwrap().categories.has_token(category)
+    }
+
+    pub fn add_category(&self, category: &str) {
+        self.impl_.lock().unwrap().categories.add_token(category);
+    }
+
+    pub fn remove_category(&self, category: &str) {
+        self.impl_.lock().unwrap().categories.remove_token(category);
+    }
+
+    pub fn get_num_categories(&self) -> usize {
+        self.impl_.lock().unwrap().categories.get_num_tokens()
+    }
+
+    pub fn get_category(&self, index: usize) -> String {
+        self.impl_.lock().unwrap().categories.get_token(index).to_string()
+    }
+
+    pub fn clear_categories(&self) {
+        self.impl_.lock().unwrap().categories.clear_tokens();
+    }
+
+    pub fn get_encoding(&self) -> String {
+        self.impl_.lock().unwrap().encoding.clone()
+    }
+
+    pub fn set_encoding(&self, encoding: &str) {
+        self.impl_.lock().unwrap().encoding = encoding.to_string();
+    }
+
+    pub fn is_data(&self) -> bool {
+        self.impl_.lock().unwrap().is_data
+    }
+
+    pub fn set_is_data(&self, val: bool) {
+        self.impl_.lock().unwrap().is_data = val;
+    }
+
+    pub fn get_reference_space_type(&self) -> ReferenceSpaceType {
+        self.impl_.lock().unwrap().reference_space_type
+    }
+
+    pub fn get_allocation(&self) -> Allocation {
+        self.impl_.lock().unwrap().allocation
+    }
+
+    pub fn set_allocation(&self, allocation: Allocation) {
+        self.impl_.lock().unwrap().allocation = allocation;
+    }
+
+    pub fn get_allocation_num_vars(&self) -> usize {
+        self.impl_.lock().unwrap().allocation_vars.len()
+    }
+
+    pub fn get_allocation_vars(&self) -> Vec<f32> {
+        self.impl_.lock().unwrap().allocation_vars.clone()
+    }
+
+    pub fn set_allocation_vars(&self, vars: &[f32]) {
+        self.impl_.lock().unwrap().allocation_vars = vars.to_vec();
+    }
+
+    pub fn get_transform(&self, dir: ColorSpaceDirection) -> Option<TransformRcPtr> {
+        match dir {
+            ColorSpaceDirection::ToReference => self.impl_.lock().unwrap().to_ref_transform.clone(),
+            ColorSpaceDirection::FromReference => self.impl_.lock().unwrap().from_ref_transform.clone(),
+        }
+    }
+
+    pub fn set_transform(&self, transform: Option<TransformRcPtr>, dir: ColorSpaceDirection) {
+        let mut impl_ = self.impl_.lock().unwrap();
+        match dir {
+            ColorSpaceDirection::ToReference => impl_.to_ref_transform = transform,
+            ColorSpaceDirection::FromReference => impl_.from_ref_transform = transform,
+        }
+    }
+}
+
+impl std::fmt::Display for ColorSpace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let impl_ = self.impl_.lock().unwrap();
+        let num_vars = impl_.allocation_vars.len();
+        let vars: Vec<String> = impl_.allocation_vars.iter().map(|v| v.to_string()).collect();
+
+        write!(
+            f,
+            "<ColorSpace referenceSpaceType={:?}, name={}, ",
+            impl_.reference_space_type, impl_.name
+        )?;
+
+        if impl_.aliases.len() == 1 {
+            write!(f, "alias={}, ", impl_.aliases[0])?;
+        } else if impl_.aliases.len() > 1 {
+            write!(f, "aliases=[{}], ", impl_.aliases.join(", "))?;
+        }
+
+        if !impl_.family.is_empty() {
+            write!(f, "family={}, ", impl_.family)?;
+        }
+
+        if !impl_.equality_group.is_empty() {
+            write!(f, "equalityGroup={}, ", impl_.equality_group)?;
+        }
+
+        if impl_.bit_depth != BitDepth::Unknown {
+            write!(f, "bitDepth={:?}, ", impl_.bit_depth)?;
+        }
+
+        write!(f, "isData={}", impl_.is_data)?;
+
+        if num_vars > 0 {
+            write!(
+                f,
+                ", allocation={:?}, vars={}",
+                impl_.allocation,
+                vars.join(" ")
+            )?;
+        }
+
+        if impl_.categories.get_num_tokens() > 0 {
+            let categories: Vec<String> = (0..impl_.categories.get_num_tokens())
+                .map(|i| impl_.categories.get_token(i).to_string())
+                .collect();
+            write!(f, ", categories={}", categories.join(","))?;
+        }
+
+        if !impl_.encoding.is_empty() {
+            write!(f, ", encoding={}", impl_.encoding)?;
+        }
+
+        if !impl_.description.is_empty() {
+            write!(f, ", description={}", impl_.description)?;
+        }
+
+        if let Some(to_ref_transform) = &impl_.to_ref_transform {
+            write!(f, ",\n    {} --> Reference\n        {}", impl_.name, to_ref_transform)?;
+        }
+
+        if let Some(from_ref_transform) = &impl_.from_ref_transform {
+            write!(f, ",\n    Reference --> {}\n        {}", impl_.name, from_ref_transform)?;
+        }
+
+        write!(f, ">")
+    }
+}

--- a/src/OpenColorIO/GPUProcessor.rs
+++ b/src/OpenColorIO/GPUProcessor.rs
@@ -1,0 +1,136 @@
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Debug)]
+pub struct GPUProcessor {
+    impl_: Arc<Mutex<Impl>>,
+}
+
+#[derive(Clone, Debug)]
+struct Impl {
+    ops: Vec<Box<dyn Op>>,
+    is_no_op: bool,
+    has_channel_crosstalk: bool,
+    cache_id: String,
+}
+
+impl Impl {
+    fn new() -> Self {
+        Impl {
+            ops: Vec::new(),
+            is_no_op: false,
+            has_channel_crosstalk: true,
+            cache_id: String::new(),
+        }
+    }
+
+    fn finalize(&mut self, raw_ops: &OpRcPtrVec, optimization_flags: OptimizationFlags) {
+        let mut ops = raw_ops.clone();
+        ops.finalize();
+        ops.optimize(optimization_flags);
+        ops.validate_dynamic_properties();
+
+        self.is_no_op = ops.is_no_op();
+        self.has_channel_crosstalk = ops.has_channel_crosstalk();
+
+        let mut ss = String::new();
+        ss.push_str(&format!("GPU Processor: oFlags {:?} ops: {}", optimization_flags, ops.get_cache_id()));
+        self.cache_id = ss;
+    }
+
+    fn extract_gpu_shader_info(&self, shader_creator: &mut GpuShaderCreator) {
+        for op in &self.ops {
+            op.extract_gpu_shader_info(shader_creator);
+        }
+
+        write_shader_header(shader_creator);
+        write_shader_footer(shader_creator);
+
+        shader_creator.finalize();
+    }
+}
+
+impl GPUProcessor {
+    pub fn new() -> Self {
+        GPUProcessor {
+            impl_: Arc::new(Mutex::new(Impl::new())),
+        }
+    }
+
+    pub fn is_no_op(&self) -> bool {
+        self.impl_.lock().unwrap().is_no_op
+    }
+
+    pub fn has_channel_crosstalk(&self) -> bool {
+        self.impl_.lock().unwrap().has_channel_crosstalk
+    }
+
+    pub fn get_cache_id(&self) -> String {
+        self.impl_.lock().unwrap().cache_id.clone()
+    }
+
+    pub fn extract_gpu_shader_info(&self, shader_desc: &mut GpuShaderDesc) {
+        let mut shader_creator = GpuShaderCreator::from(shader_desc);
+        self.impl_.lock().unwrap().extract_gpu_shader_info(&mut shader_creator);
+    }
+
+    pub fn extract_gpu_shader_info_with_creator(&self, shader_creator: &mut GpuShaderCreator) {
+        let mut key = shader_creator.get_cache_id().to_string();
+        key.push_str(&self.impl_.lock().unwrap().cache_id);
+
+        let key = cache_id_hash(&key);
+
+        if !key.chars().next().unwrap().is_alphabetic() {
+            key.insert(0, 'k');
+        }
+
+        let key = key.chars().filter(|c| c.is_alphanumeric() || *c == '_').collect::<String>();
+
+        shader_creator.begin(&key);
+
+        self.impl_.lock().unwrap().extract_gpu_shader_info(shader_creator);
+
+        shader_creator.end();
+    }
+}
+
+fn write_shader_header(shader_creator: &mut GpuShaderCreator) {
+    let fcn_name = shader_creator.get_function_name().to_string();
+
+    let mut ss = GpuShaderText::new(shader_creator.get_language());
+
+    ss.new_line();
+    ss.new_line().push_str("// Declaration of the OCIO shader function");
+    ss.new_line();
+
+    if shader_creator.get_language() == GpuLanguage::OSL_1 {
+        ss.new_line().push_str(&format!("color4 {}(color4 inPixel)", fcn_name));
+        ss.new_line().push_str("{");
+        ss.indent();
+        ss.new_line().push_str(&format!("color4 {} = inPixel;", shader_creator.get_pixel_name()));
+    } else {
+        ss.new_line().push_str(&format!("{} {}({} inPixel)", ss.float4_keyword(), fcn_name, ss.float4_keyword()));
+        ss.new_line().push_str("{");
+        ss.indent();
+        ss.new_line().push_str(&format!("{} {} = inPixel;", ss.float4_decl(), shader_creator.get_pixel_name()));
+    }
+
+    shader_creator.add_to_function_header_shader_code(&ss.string());
+}
+
+fn write_shader_footer(shader_creator: &mut GpuShaderCreator) {
+    let mut ss = GpuShaderText::new(shader_creator.get_language());
+
+    ss.new_line();
+    ss.indent();
+    ss.new_line().push_str(&format!("return {};", shader_creator.get_pixel_name()));
+    ss.dedent();
+    ss.new_line().push_str("}");
+
+    shader_creator.add_to_function_footer_shader_code(&ss.string());
+}
+
+fn cache_id_hash(key: &str) -> String {
+    let hash = xxhash_rust::xxh3::xxh3_128(key.as_bytes());
+
+    format!("{:x}{:x}", hash.low64, hash.high64)
+}


### PR DESCRIPTION
Convert the C++ code of the OpenColorIO project to Rust, avoiding the use of `unsafe`.

* **ColorSpace.rs**
  - Implement `ColorSpace` struct and its methods in Rust.
  - Translate `Impl` class to a nested struct within `ColorSpace`.
  - Replace C++ specific libraries and headers with Rust equivalents.

* **CPUProcessor.rs**
  - Implement `CPUProcessor` struct and its methods in Rust.
  - Translate `Impl` class to a nested struct within `CPUProcessor`.
  - Replace C++ specific libraries and headers with Rust equivalents.

* **GPUProcessor.rs**
  - Implement `GPUProcessor` struct and its methods in Rust.
  - Translate `Impl` class to a nested struct within `GPUProcessor`.
  - Replace C++ specific libraries and headers with Rust equivalents.

* **Cargo.toml**
  - Add dependencies for Rust equivalents of C++ libraries used in the project.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Hashory/OpenColorIO/pull/1?shareId=aa4497f8-838d-4da8-a005-760821d2d356).